### PR TITLE
feat(patch): Arena Crystals fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 CMakeLists.txt.user
 *.bak
 *.patch
+!arena-crystals-fix.patch
 *.diff
 *.REMOTE.*
 *.BACKUP.*

--- a/README.md
+++ b/README.md
@@ -15,17 +15,16 @@
 
 ### How to install
 1. Simply place the module under the `modules` folder of your AzerothCore source folder.
-2. (Optional) You can apply the ``arena-crystals-fix.patch`` to your core using ``git apply arena-crystals-fix.patch``, this patch also apply a fast start to arena crystals, until the original piece of code applys a delay of 15s, we changed to 5s for make arenas startup faster. :) (This patch its also avaliable on [Pastebin](https://pastebin.com/raw/Jw8XexQy)).
+2. Apply the ``arena-crystals-fix.patch`` to your core using ``git apply arena-crystals-fix.patch``, this patch also apply a fast start to arena crystals, until the original piece of code applys a delay of 15s, we changed to 5s for make arenas startup faster. :) (This patch its also avaliable on [Pastebin](https://pastebin.com/raw/Jw8XexQy)).
 3. Re-run cmake and launch a clean build of AzerothCore
 4. Run the Sql file into your database.
 5. Ready.
 
 ### Usage
-- Enable the module and join 1 v 1 with 2 characters at the BattleMaster Npc.
+- Enable the module, apply the patch, build, open the server and join 1v1 with 2 characters at the BattleMaster Npc.
 
 ### Info
-This module runs over the 5v5.You can configure it to run over 4v4/3v3..etc As you desire.
-
+This module runs over the 5v5. If you want to run without replace the arena 5v5 mode, you can edit the configuration to works without any chart, or also can make your own changes.
 
 ## Credits
 * [XDev](https://github.com/XdevTLKWoW): 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@
 
 ### How to install
 1. Simply place the module under the `modules` folder of your AzerothCore source folder.
-2. Re-run cmake and launch a clean build of AzerothCore
-3. Run the Sql file into your database.
-4. Ready.
+2. (Optional) You can apply the ``arena-crystals-fix.patch`` to your core using ``git apply arena-crystals-fix.patch``, this patch also apply a fast start to arena crystals, until the original piece of code applys a delay of 15s, we changed to 5s for make arenas startup faster. :) (This patch its also avaliable on [Pastebin](https://pastebin.com/raw/Jw8XexQy)).
+3. Re-run cmake and launch a clean build of AzerothCore
+4. Run the Sql file into your database.
+5. Ready.
 
 ### Usage
 - Enable the module and join 1 v 1 with 2 characters at the BattleMaster Npc.

--- a/arena-crystals-fix.patch
+++ b/arena-crystals-fix.patch
@@ -1,18 +1,111 @@
-From 72a55618eaeb378573d7f5562f8b428b0f648ceb Mon Sep 17 00:00:00 2001
+From d6ccd22d973259b15c94dfb5d36cf6b04e21132c Mon Sep 17 00:00:00 2001
 From: Rastrian <me@rastrian.dev>
-Date: Thu, 10 Sep 2020 10:21:41 -0300
-Subject: [PATCH] fix(1v1-module): Fixed delay event and Arena Crystals.
+Date: Thu, 10 Sep 2020 13:18:57 -0300
+Subject: [PATCH] Fix patch for 1v1 Arena
 
 ---
- src/server/game/Battlegrounds/Battleground.cpp | 10 +++++++---
- src/server/game/Battlegrounds/Battleground.h   |  1 +
- 2 files changed, 8 insertions(+), 3 deletions(-)
+ src/server/game/Battlegrounds/ArenaTeam.cpp    | 18 ++++++++++++++++++
+ src/server/game/Battlegrounds/ArenaTeam.h      |  7 +++++++
+ src/server/game/Battlegrounds/Battleground.cpp | 10 ++++++----
+ src/server/game/Battlegrounds/Battleground.h   |  5 +++++
+ .../game/Battlegrounds/BattlegroundMgr.cpp     | 16 ++++++++++++++++
+ .../Entities/Object/Updates/UpdateFields.h     | 15 +++++++++++++++
+ src/server/game/Entities/Player/Player.cpp     | 10 +++++++++-
+ .../game/Handlers/BattleGroundHandler.cpp      | 12 ++++++++++--
+ src/server/game/Miscellaneous/SharedDefines.h  |  3 +++
+ src/server/game/World/World.cpp                |  3 +++
+ src/server/game/World/World.h                  |  4 ++++
+ 11 files changed, 96 insertions(+), 7 deletions(-)
 
+diff --git a/src/server/game/Battlegrounds/ArenaTeam.cpp b/src/server/game/Battlegrounds/ArenaTeam.cpp
+index 5fddb6ae..fd0ce4ef 100644
+--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
++++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
+@@ -81,7 +81,9 @@ bool ArenaTeam::AddMember(uint64 playerGuid)
+ 
+     // Check if arena team is full (Can't have more than type * 2 players)
+     if (GetMembersSize() >= GetType() * 2)
++    {
+         return false;
++    }
+ 
+     // xinef: Get player name and class from player storage or global data storage
+     Player* player = ObjectAccessor::FindPlayerInOrOutOfWorld(playerGuid);
+@@ -434,6 +436,15 @@ void ArenaTeam::Roster(WorldSession* session)
+ 
+ void ArenaTeam::Query(WorldSession* session)
+ {
++    #ifdef mod_1v1arena
++        if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
++        {
++            if (GetType() == 1)
++            {
++                return;
++            }
++        }
++    #endif
+     WorldPacket data(SMSG_ARENA_TEAM_QUERY_RESPONSE, 4*7+GetName().size()+1);
+     data << uint32(GetId());                                // team id
+     data << GetName();                                      // team name
+@@ -585,6 +596,9 @@ uint8 ArenaTeam::GetSlotByType(uint32 type)
+         case ARENA_TEAM_2v2: return 0;
+         case ARENA_TEAM_3v3: return 1;
+         case ARENA_TEAM_5v5: return 2;
++#ifdef mod_1v1arena
++        case ARENA_TEAM_1v1: return 3;
++#endif
+         default:
+             break;
+     }
+@@ -623,6 +637,10 @@ uint32 ArenaTeam::GetPoints(uint32 memberRating)
+         points *= 0.76f;
+     else if (Type == ARENA_TEAM_3v3)
+         points *= 0.88f;
++#ifdef mod_1v1arena
++    else if(Type == ARENA_TEAM_1v1)
++        points *= sConfigMgr->GetFloatDefault("Arena.1v1.ArenaPointsMulti", 0.64f);
++#endif
+ 
+     points *= sWorld->getRate(RATE_ARENA_POINTS);
+ 
+diff --git a/src/server/game/Battlegrounds/ArenaTeam.h b/src/server/game/Battlegrounds/ArenaTeam.h
+index bf3dab21..5fa6a2ae 100644
+--- a/src/server/game/Battlegrounds/ArenaTeam.h
++++ b/src/server/game/Battlegrounds/ArenaTeam.h
+@@ -68,6 +68,9 @@ ERR_ARENA_TEAM_LEVEL_TOO_LOW_I
+ 
+ enum ArenaTeamTypes
+ {
++#ifdef mod_1v1arena
++    ARENA_TEAM_1v1      = 1,
++#endif
+     ARENA_TEAM_2v2      = 2,
+     ARENA_TEAM_3v3      = 3,
+     ARENA_TEAM_5v5      = 5
+@@ -101,6 +104,10 @@ struct ArenaTeamStats
+ };
+ 
+ #define MAX_ARENA_SLOT 3                                    // 0..2 slots
++#ifdef mod_1v1arena
++#undef MAX_ARENA_SLOT
++#define MAX_ARENA_SLOT 4                                    // 0..3 slots
++#endif
+ 
+ class ArenaTeam
+ {
 diff --git a/src/server/game/Battlegrounds/Battleground.cpp b/src/server/game/Battlegrounds/Battleground.cpp
-index b9a95b94..30ba7d6f 100644
+index b9a95b94..b173869e 100644
 --- a/src/server/game/Battlegrounds/Battleground.cpp
 +++ b/src/server/game/Battlegrounds/Battleground.cpp
-@@ -1378,17 +1378,21 @@ void Battleground::SpectatorsSendPacket(WorldPacket& data)
+@@ -33,6 +33,7 @@
+ #include "Transport.h"
+ #include "ScriptMgr.h"
+ #include "GameGraveyard.h"
++#include <Config.h>
+ #ifdef ELUNA
+ #include "LuaEngine.h"
+ #endif
+@@ -1378,17 +1378,19 @@ void Battleground::SpectatorsSendPacket(WorldPacket& data)
  
  void Battleground::ReadyMarkerClicked(Player* p)
  {
@@ -22,9 +115,11 @@ index b9a95b94..30ba7d6f 100644
      readyMarkerClickedSet.insert(p->GetGUIDLow());
      uint32 count = readyMarkerClickedSet.size();
      uint32 req = GetArenaType()*2;
-+    if (req == 10) // Arena 1v1
-+        req = 2;
-     p->GetSession()->SendNotification("You are marked as ready %u/%u", count, req);
+-    p->GetSession()->SendNotification("You are marked as ready %u/%u", count, req);
++    if ((sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 5) && (sConfigMgr->GetIntDefault("Arena1v1.Enable", 1) == 1) && (req == 10))
++    {
++        count = 2;
++    }
      if (count == req)
      {
          m_Events |= BG_STARTING_EVENT_2;
@@ -32,11 +127,14 @@ index b9a95b94..30ba7d6f 100644
 -        SetStartDelayTime(BG_START_DELAY_15S);
 +        m_StartTime += GetStartDelayTime()-BG_START_DELAY_5S;
 +        SetStartDelayTime(BG_START_DELAY_5S);
++        p->GetSession()->SendNotification("The arena will start in 5 seconds.");
++    } else {
++        p->GetSession()->SendNotification("You are marked as ready %u/%u", count, req);
      }
  }
  
 diff --git a/src/server/game/Battlegrounds/Battleground.h b/src/server/game/Battlegrounds/Battleground.h
-index 7a2fd35c..9fe8d3ad 100644
+index 7a2fd35c..88c2d6a1 100644
 --- a/src/server/game/Battlegrounds/Battleground.h
 +++ b/src/server/game/Battlegrounds/Battleground.h
 @@ -143,6 +143,7 @@ enum BattlegroundStartTimeIntervals
@@ -47,6 +145,207 @@ index 7a2fd35c..9fe8d3ad 100644
      BG_START_DELAY_NONE             = 0,                    // ms
  };
  
+@@ -210,6 +211,10 @@ enum ScoreType
+ 
+ enum ArenaType
+ {
++#ifdef mod_1v1arena
++    //Add special arena type for 1v1 so we dont need to disable 5v5
++    ARENA_TYPE_1v1          = 1,
++#endif
+     ARENA_TYPE_2v2          = 2,
+     ARENA_TYPE_3v3          = 3,
+     ARENA_TYPE_5v5          = 5
+diff --git a/src/server/game/Battlegrounds/BattlegroundMgr.cpp b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+index 6dbf016f..f7aa26dc 100644
+--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
++++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+@@ -470,6 +470,11 @@ Battleground* BattlegroundMgr::CreateNewBattleground(BattlegroundTypeId original
+         uint32 maxPlayersPerTeam = 0;
+         switch (arenaType)
+         {
++#ifdef mod_1v1arena
++            case ARENA_TYPE_1v1:
++                maxPlayersPerTeam = 1;
++                break;
++#endif
+             case ARENA_TYPE_2v2:
+                 maxPlayersPerTeam = 2;
+                 break;
+@@ -755,6 +760,10 @@ BattlegroundQueueTypeId BattlegroundMgr::BGQueueTypeId(BattlegroundTypeId bgType
+                 return BATTLEGROUND_QUEUE_3v3;
+             case ARENA_TYPE_5v5:
+                 return BATTLEGROUND_QUEUE_5v5;
++#ifdef mod_1v1arena
++            case ARENA_TYPE_1v1:
++                return BATTLEGROUND_QUEUE_1v1;
++#endif
+             default:
+                 return BATTLEGROUND_QUEUE_NONE;
+         }
+@@ -786,6 +795,10 @@ uint8 BattlegroundMgr::BGArenaType(BattlegroundQueueTypeId bgQueueTypeId)
+             return ARENA_TYPE_3v3;
+         case BATTLEGROUND_QUEUE_5v5:
+             return ARENA_TYPE_5v5;
++#ifdef mod_1v1arena
++        case BATTLEGROUND_QUEUE_1v1:
++            return ARENA_TYPE_1v1;
++#endif
+         default:
+             return 0;
+     }
+@@ -1080,6 +1093,9 @@ std::unordered_map<int, BattlegroundTypeId> BattlegroundMgr::queueToBg = {
+     { BATTLEGROUND_QUEUE_2v2,   BATTLEGROUND_AA },
+     { BATTLEGROUND_QUEUE_3v3,   BATTLEGROUND_AA },
+     { BATTLEGROUND_QUEUE_5v5,   BATTLEGROUND_AA },
++#ifdef mod_1v1arena
++    { BATTLEGROUND_QUEUE_1v1,   BATTLEGROUND_AA },
++#endif
+ };
+ 
+ std::unordered_map<int, Battleground*> BattlegroundMgr::bgtypeToBattleground = {
+diff --git a/src/server/game/Entities/Object/Updates/UpdateFields.h b/src/server/game/Entities/Object/Updates/UpdateFields.h
+index 667423bd..93a552a0 100644
+--- a/src/server/game/Entities/Object/Updates/UpdateFields.h
++++ b/src/server/game/Entities/Object/Updates/UpdateFields.h
+@@ -367,6 +367,20 @@ enum EUnitFields
+     PLAYER_FIELD_BYTES2                       = UNIT_END + 0x0439, // Size: 1, Type: 6, Flags: PRIVATE
+     PLAYER_FIELD_WATCHED_FACTION_INDEX        = UNIT_END + 0x043A, // Size: 1, Type: INT, Flags: PRIVATE
+     PLAYER_FIELD_COMBAT_RATING_1              = UNIT_END + 0x043B, // Size: 25, Type: INT, Flags: PRIVATE
++#ifdef mod_1v1arena
++    PLAYER_FIELD_ARENA_TEAM_INFO_1_1 = UNIT_END + 0x0454, // Size: 28, Type: INT, Flags: PRIVATE
++    PLAYER_FIELD_HONOR_CURRENCY = UNIT_END + 0x0470, // Size: 1, Type: INT, Flags: PRIVATE
++    PLAYER_FIELD_ARENA_CURRENCY = UNIT_END + 0x0471, // Size: 1, Type: INT, Flags: PRIVATE
++    PLAYER_FIELD_MAX_LEVEL = UNIT_END + 0x0472, // Size: 1, Type: INT, Flags: PRIVATE
++    PLAYER_FIELD_DAILY_QUESTS_1 = UNIT_END + 0x0473, // Size: 25, Type: INT, Flags: PRIVATE
++    PLAYER_RUNE_REGEN_1 = UNIT_END + 0x048C, // Size: 4, Type: FLOAT, Flags: PRIVATE
++    PLAYER_NO_REAGENT_COST_1 = UNIT_END + 0x0490, // Size: 3, Type: INT, Flags: PRIVATE
++    PLAYER_FIELD_GLYPH_SLOTS_1 = UNIT_END + 0x0493, // Size: 6, Type: INT, Flags: PRIVATE
++    PLAYER_FIELD_GLYPHS_1 = UNIT_END + 0x0499, // Size: 6, Type: INT, Flags: PRIVATE
++    PLAYER_GLYPHS_ENABLED = UNIT_END + 0x049F, // Size: 1, Type: INT, Flags: PRIVATE
++    PLAYER_PET_SPELL_POWER = UNIT_END + 0x04A0, // Size: 1, Type: INT, Flags: PRIVATE
++    PLAYER_END = UNIT_END + 0x04A1,
++#else
+     PLAYER_FIELD_ARENA_TEAM_INFO_1_1          = UNIT_END + 0x0454, // Size: 21, Type: INT, Flags: PRIVATE
+     PLAYER_FIELD_HONOR_CURRENCY               = UNIT_END + 0x0469, // Size: 1, Type: INT, Flags: PRIVATE
+     PLAYER_FIELD_ARENA_CURRENCY               = UNIT_END + 0x046A, // Size: 1, Type: INT, Flags: PRIVATE
+@@ -379,6 +393,7 @@ enum EUnitFields
+     PLAYER_GLYPHS_ENABLED                     = UNIT_END + 0x0498, // Size: 1, Type: INT, Flags: PRIVATE
+     PLAYER_PET_SPELL_POWER                    = UNIT_END + 0x0499, // Size: 1, Type: INT, Flags: PRIVATE
+     PLAYER_END                                = UNIT_END + 0x049A,
++#endif
+ };
+ 
+ enum EGameObjectFields
+diff --git a/src/server/game/Entities/Player/Player.cpp b/src/server/game/Entities/Player/Player.cpp
+index 7395e9e2..f69bd25c 100644
+--- a/src/server/game/Entities/Player/Player.cpp
++++ b/src/server/game/Entities/Player/Player.cpp
+@@ -17602,7 +17602,7 @@ void Player::_LoadArenaTeamInfo()
+ {
+     memset((void*)&m_uint32Values[PLAYER_FIELD_ARENA_TEAM_INFO_1_1], 0, sizeof(uint32) * MAX_ARENA_SLOT * ARENA_TEAM_END);
+ 
+-    for (uint8 slot = 0; slot <= 2; ++slot)
++    for (uint8 slot = 0; slot < MAX_ARENA_SLOT; ++slot)
+         if (uint32 arenaTeamId = Player::GetArenaTeamIdFromStorage(GetGUIDLow(), slot))
+         {
+             ArenaTeam* arenaTeam = sArenaTeamMgr->GetArenaTeamById(arenaTeamId);
+@@ -22224,6 +22224,10 @@ bool Player::BuyItemFromVendorSlot(uint64 vendorguid, uint32 vendorslot, uint32
+     return crItem->maxcount != 0;
+ }
+ 
++#ifdef mod_1v1arena
++#include <Config.h>
++#endif
++
+ uint32 Player::GetMaxPersonalArenaRatingRequirement(uint32 minarenaslot) const
+ {
+     // returns the maximal personal arena rating that can be used to purchase items requiring this condition
+@@ -22232,6 +22236,10 @@ uint32 Player::GetMaxPersonalArenaRatingRequirement(uint32 minarenaslot) const
+     uint32 max_personal_rating = 0;
+     for (uint8 i = minarenaslot; i < MAX_ARENA_SLOT; ++i)
+     {
++#ifdef mod_1v1arena
++        if (i == ArenaTeam::GetSlotByType(ARENA_TYPE_1v1) && sConfigMgr->GetBoolDefault("Arena.1v1.VendorRating", false) == false) continue;
++#endif
++
+         if (ArenaTeam* at = sArenaTeamMgr->GetArenaTeamById(GetArenaTeamId(i)))
+         {
+             uint32 p_rating = GetArenaPersonalRating(i);
+diff --git a/src/server/game/Handlers/BattleGroundHandler.cpp b/src/server/game/Handlers/BattleGroundHandler.cpp
+index 949f88c9..22756e99 100644
+--- a/src/server/game/Handlers/BattleGroundHandler.cpp
++++ b/src/server/game/Handlers/BattleGroundHandler.cpp
+@@ -156,7 +156,11 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket & recvData)
+             err = ERR_IN_NON_RANDOM_BG;
+         else if (_player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_2v2) ||
+                  _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_3v3) ||
+-                 _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)) // can't be already queued for arenas
++                 _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)
++#ifdef mod_1v1arena
++            || _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_1v1)
++#endif
++            ) // can't be already queued for arenas
+             err = ERR_BATTLEGROUND_QUEUED_FOR_RATED;
+         // don't let Death Knights join BG queues when they are not allowed to be teleported yet
+         else if (_player->getClass() == CLASS_DEATH_KNIGHT && _player->GetMapId() == 609 && !_player->IsGameMaster() && !_player->HasSpell(50977))
+@@ -222,7 +226,11 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPacket & recvData)
+             err = ERR_IN_NON_RANDOM_BG;
+         else if (_player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_2v2) ||
+                  _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_3v3) ||
+-                 _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)) // can't be already queued for arenas
++                 _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5)
++#ifdef mod_1v1arena
++                || _player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_1v1)
++#endif
++                ) // can't be already queued for arenas
+             err = ERR_BATTLEGROUND_QUEUED_FOR_RATED;
+ 
+         if (err > 0)
+diff --git a/src/server/game/Miscellaneous/SharedDefines.h b/src/server/game/Miscellaneous/SharedDefines.h
+index 123e4844..96c9ee94 100644
+--- a/src/server/game/Miscellaneous/SharedDefines.h
++++ b/src/server/game/Miscellaneous/SharedDefines.h
+@@ -3431,6 +3431,9 @@ enum BattlegroundQueueTypeId
+     BATTLEGROUND_QUEUE_2v2       = 8,
+     BATTLEGROUND_QUEUE_3v3       = 9,
+     BATTLEGROUND_QUEUE_5v5       = 10,
++#ifdef mod_1v1arena
++    BATTLEGROUND_QUEUE_1v1       = 11,
++#endif
+     MAX_BATTLEGROUND_QUEUE_TYPES = 20,
+ };
+ 
+diff --git a/src/server/game/World/World.cpp b/src/server/game/World/World.cpp
+index 1ed8956f..f159321a 100644
+--- a/src/server/game/World/World.cpp
++++ b/src/server/game/World/World.cpp
+@@ -3232,6 +3232,9 @@ void World::AddGlobalPlayerData(uint32 guid, uint32 accountId, std::string const
+     data.arenaTeamId[0] = 0;
+     data.arenaTeamId[1] = 0;
+     data.arenaTeamId[2] = 0;
++#ifdef mod_1v1arena
++    data.arenaTeamId[3] = 0;
++#endif
+ 
+     _globalPlayerDataStore[guid] = data;
+     _globalPlayerNameStore[name] = guid;
+diff --git a/src/server/game/World/World.h b/src/server/game/World/World.h
+index e8a09cd5..ae7b9d1a 100644
+--- a/src/server/game/World/World.h
++++ b/src/server/game/World/World.h
+@@ -581,7 +581,11 @@ struct GlobalPlayerData
+     uint16 mailCount;
+     uint32 guildId;
+     uint32 groupId;
++#ifdef mod_1v1arena
++    uint32 arenaTeamId[4];
++#else
+     uint32 arenaTeamId[3];
++#endif
+ };
+ 
+ enum GlobalPlayerUpdateMask
 -- 
 2.27.0.windows.1
 

--- a/arena-crystals-fix.patch
+++ b/arena-crystals-fix.patch
@@ -1,0 +1,52 @@
+From 72a55618eaeb378573d7f5562f8b428b0f648ceb Mon Sep 17 00:00:00 2001
+From: Rastrian <me@rastrian.dev>
+Date: Thu, 10 Sep 2020 10:21:41 -0300
+Subject: [PATCH] fix(1v1-module): Fixed delay event and Arena Crystals.
+
+---
+ src/server/game/Battlegrounds/Battleground.cpp | 10 +++++++---
+ src/server/game/Battlegrounds/Battleground.h   |  1 +
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/src/server/game/Battlegrounds/Battleground.cpp b/src/server/game/Battlegrounds/Battleground.cpp
+index b9a95b94..30ba7d6f 100644
+--- a/src/server/game/Battlegrounds/Battleground.cpp
++++ b/src/server/game/Battlegrounds/Battleground.cpp
+@@ -1378,17 +1378,21 @@ void Battleground::SpectatorsSendPacket(WorldPacket& data)
+ 
+ void Battleground::ReadyMarkerClicked(Player* p)
+ {
+-    if (!isArena() || GetStatus() >= STATUS_IN_PROGRESS || GetStartDelayTime() <= BG_START_DELAY_15S || (m_Events & BG_STARTING_EVENT_3) || p->IsSpectator())
++    if (!isArena() || GetStatus() >= STATUS_IN_PROGRESS || GetStartDelayTime() <= BG_START_DELAY_5S || (m_Events & BG_STARTING_EVENT_3) || p->IsSpectator())
+         return;
+     readyMarkerClickedSet.insert(p->GetGUIDLow());
+     uint32 count = readyMarkerClickedSet.size();
+     uint32 req = GetArenaType()*2;
++    if (req == 10) // Arena 1v1
++        req = 2;
+     p->GetSession()->SendNotification("You are marked as ready %u/%u", count, req);
+     if (count == req)
+     {
+         m_Events |= BG_STARTING_EVENT_2;
+-        m_StartTime += GetStartDelayTime()-BG_START_DELAY_15S;
+-        SetStartDelayTime(BG_START_DELAY_15S);
++        m_StartTime += GetStartDelayTime()-BG_START_DELAY_5S;
++        SetStartDelayTime(BG_START_DELAY_5S);
+     }
+ }
+ 
+diff --git a/src/server/game/Battlegrounds/Battleground.h b/src/server/game/Battlegrounds/Battleground.h
+index 7a2fd35c..9fe8d3ad 100644
+--- a/src/server/game/Battlegrounds/Battleground.h
++++ b/src/server/game/Battlegrounds/Battleground.h
+@@ -143,6 +143,7 @@ enum BattlegroundStartTimeIntervals
+     BG_START_DELAY_1M               = 60000,                // ms (1 minute)
+     BG_START_DELAY_30S              = 30000,                // ms (30 seconds)
+     BG_START_DELAY_15S              = 15000,                // ms (15 seconds) Used only in arena
++    BG_START_DELAY_5S               = 5000,                 // ms (5 seconds) Used only in arena
+     BG_START_DELAY_NONE             = 0,                    // ms
+ };
+ 
+-- 
+2.27.0.windows.1
+

--- a/conf/1v1arena.conf.dist
+++ b/conf/1v1arena.conf.dist
@@ -10,14 +10,23 @@
 
 Arena1v1.Enable = 1
 
-#    NOT IMPLEMENTED
 #    Arena.1v1.Announcer
 #        Description: Announce 1v1 arena queue status to chat.
-#                      Arena.QueueAnnouncer.Enable must be enabled.
+#                     Arena.QueueAnnouncer.Enable must be enabled.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 
 Arena1v1Announcer.Enable = 1
+
+#
+#    Arena.1v1.Mode
+#        Description: Change the mode of the arena use method (1v1 or 5v5).
+#                     This method needs a patch to work, avaliable on github repository.
+#                     The unrated arena will only work with 1v1 Arena (value 1).
+#        Default:     5 (Uses 5v5 Arena)
+#                     1 (Uses 1v1 Arena - Needs apply a patch)
+
+Arena.1v1.Mode = 5
 
 #
 #    Arena.1v1.MinLevel
@@ -38,7 +47,7 @@ Arena1v1Costs = 400000
 #        Description: If true, 1v1 rating will use to calculate highest personal-rating (extended costs).
 #                      Note: The vendor-item will show as not buyable (red), but players can buy it, if enabled and rating is high enough.
 #        Default:     0 - (false)
-#                      1 - (true)
+#                     1 - (true)
 
 Arena.1v1.VendorRating = 0
 
@@ -53,6 +62,7 @@ Arena.1v1.VendorRating = 0
 
 Arena.1v1.ArenaPointsMulti = 0.64
 
+#    NOT IMPLEMENTED
 #
 #    Arena.1v1.BlockForbiddenTalents
 #        Description: If true, healers can't join 1v1 arena, if they invested more than 35 talentpoints in a healing-talenttree.

--- a/src/npc_arena1v1.cpp
+++ b/src/npc_arena1v1.cpp
@@ -65,22 +65,41 @@ public:
             return true;
         }
 
-        if (player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue leave 1v1 Arena", GOSSIP_SENDER_MAIN, 3, "Are you sure?", 0, false);
-        else
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena(UnRated)", GOSSIP_SENDER_MAIN, 20);
-
-        if (!player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5)))
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Create new 1v1 Arena Team", GOSSIP_SENDER_MAIN, 1, "Are you sure?", sConfigMgr->GetIntDefault("Arena1v1Costs", 400000), false);
-        else
+        if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
         {
-            if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
-            {
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena (Rated)", GOSSIP_SENDER_MAIN, 2);
-                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Arenateam Clear", GOSSIP_SENDER_MAIN, 5, "Are you sure?", 0, false);
-            }
+            if (player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_1v1))
+                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue leave 1v1 Arena", GOSSIP_SENDER_MAIN, 3, "Are you sure?", 0, false);
+            else
+                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena (UnRated)", GOSSIP_SENDER_MAIN, 20);
 
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Shows your statistics", GOSSIP_SENDER_MAIN, 4);
+            if (!player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_1v1)))
+                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Create new 1v1 Arena Team", GOSSIP_SENDER_MAIN, 1, "Are you sure?", sConfigMgr->GetIntDefault("Arena1v1Costs", 400000), false);
+            else
+            {
+                if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_1v1))
+                {
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena (Rated)", GOSSIP_SENDER_MAIN, 2);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Arenateam Clear", GOSSIP_SENDER_MAIN, 5, "Are you sure?", 0, false);
+                }
+
+                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Shows your statistics", GOSSIP_SENDER_MAIN, 4);
+            }
+        } else {
+            if (player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
+                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue leave 1v1 Arena", GOSSIP_SENDER_MAIN, 3, "Are you sure?", 0, false);
+
+            if (!player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5)))
+                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Create new 1v1 Arena Team", GOSSIP_SENDER_MAIN, 1, "Are you sure?", sConfigMgr->GetIntDefault("Arena1v1Costs", 400000), false);
+            else
+            {
+                if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
+                {
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena (Rated)", GOSSIP_SENDER_MAIN, 2);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Arenateam Clear", GOSSIP_SENDER_MAIN, 5, "Are you sure?", 0, false);
+                }
+
+                AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Shows your statistics", GOSSIP_SENDER_MAIN, 4);
+            }
         }
 
         SendGossipMenuFor(player, 68, creature);
@@ -138,8 +157,16 @@ public:
         {
             uint8 arenaType = ARENA_TYPE_5v5;
 
-            if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
-                return true;
+            if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 5)
+            {
+                if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
+                    return true;
+            } else {
+                arenaType = ARENA_TYPE_1v1;
+
+                if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_1v1))
+                    return true;
+            }
 
             WorldPacket data;
             data << arenaType << (uint8)0x0 << (uint32)BATTLEGROUND_AA << (uint16)0x0 << (uint8)0x0;
@@ -152,6 +179,12 @@ public:
         case 4: // get statistics
         {
             ArenaTeam* at = sArenaTeamMgr->GetArenaTeamById(player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5)));
+
+            if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
+            {
+                at = sArenaTeamMgr->GetArenaTeamById(player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_1v1)));
+            }
+
             if (at)
             {
                 std::stringstream s;
@@ -170,7 +203,12 @@ public:
         case 5: // Disband arenateam
         {
             WorldPacket Data;
-            Data << (uint32)player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5));
+            if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
+            {
+                Data << (uint32)player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_1v1));
+            } else {
+                Data << (uint32)player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5));
+            }
             player->GetSession()->HandleArenaTeamLeaveOpcode(Data);
             handler.SendSysMessage("Arenateam deleted!");
             CloseGossipMenuFor(player);
@@ -194,6 +232,13 @@ private:
 
         uint8 arenaslot = ArenaTeam::GetSlotByType(ARENA_TEAM_5v5);
         uint8 arenatype = ARENA_TYPE_5v5;
+
+        if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
+        {
+            arenaslot = ArenaTeam::GetSlotByType(ARENA_TEAM_1v1);
+            arenatype = ARENA_TYPE_1v1;
+        }
+
         uint32 arenaRating = 0;
         uint32 matchmakerRating = 0;
 
@@ -205,11 +250,11 @@ private:
         Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(BATTLEGROUND_AA);
         if (!bg)
         {
-            sLog->outString("Battleground: template bg (all arenas) not found");
+            sLog->outDebug(LOG_FILTER_NETWORKIO, "Battleground: template bg (all arenas) not found");
             return false;
         }
 
-        if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, BATTLEGROUND_AA, nullptr))
+        if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, BATTLEGROUND_AA, NULL))
         {
             ChatHandler(player->GetSession()).PSendSysMessage(LANG_ARENA_DISABLED);
             return false;
@@ -223,7 +268,7 @@ private:
 
         // check if already in queue
         if (player->GetBattlegroundQueueIndex(bgQueueTypeId) < PLAYER_MAX_BATTLEGROUND_QUEUES)
-            return false; // //player is already in this queue
+            return false; //player is already in this queue
 
         // check if has free queue slots
         if (!player->HasFreeBattlegroundQueueId())
@@ -253,13 +298,20 @@ private:
         BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
         bg->SetRated(isRated);
 
-        GroupQueueInfo* ginfo = bgQueue.AddGroup(player, nullptr, bracketEntry, isRated, false, arenaRating, matchmakerRating, ateamId);
+        GroupQueueInfo* ginfo = bgQueue.AddGroup(player, NULL, bracketEntry, isRated, false, arenaRating, matchmakerRating, ateamId);
         uint32 avgTime = bgQueue.GetAverageQueueWaitTime(ginfo);
         uint32 queueSlot = player->AddBattlegroundQueueId(bgQueueTypeId);
 
         // send status packet (in queue)
         WorldPacket data;
-        sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_WAIT_QUEUE, avgTime, 0, arenatype, TEAM_NEUTRAL, isRated);
+
+        if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
+        {
+            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_WAIT_QUEUE, avgTime, 0, arenatype, TEAM_NEUTRAL);
+        } else {
+            sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, bg, queueSlot, STATUS_WAIT_QUEUE, avgTime, 0, arenatype, TEAM_NEUTRAL, isRated);
+        }
+
         player->GetSession()->SendPacket(&data);
 
         sBattlegroundMgr->ScheduleArenaQueueUpdate(matchmakerRating, bgQueueTypeId, bracketEntry->GetBracketId());
@@ -272,7 +324,13 @@ private:
         if (!player || !me)
             return false;
 
-        uint8 slot = ArenaTeam::GetSlotByType(ARENA_TEAM_5v5);
+        uint8 slot = ArenaTeam::GetSlotByType(ARENA_TEAM_5v5); 
+
+        if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
+        {
+            slot = ArenaTeam::GetSlotByType(ARENA_TEAM_1v1);
+        }
+
         if (slot >= MAX_ARENA_SLOT)
             return false;
 
@@ -302,10 +360,20 @@ private:
 
         // Create arena team
         ArenaTeam* arenaTeam = new ArenaTeam();
-        if (!arenaTeam->Create(player->GetGUID(), ARENA_TEAM_5v5, teamName.str(), 4283124816, 45, 4294242303, 5, 4294705149))
+
+        if (sConfigMgr->GetIntDefault("Arena.1v1.Mode", 5) == 1)
         {
-            delete arenaTeam;
-            return false;
+            if (!arenaTeam->Create(player->GetGUID(), ARENA_TEAM_1v1, teamName.str(), 4283124816, 45, 4294242303, 5, 4294705149))
+            {
+                delete arenaTeam;
+                return false;
+            }
+        } else {
+            if (!arenaTeam->Create(player->GetGUID(), ARENA_TEAM_5v5, teamName.str(), 4283124816, 45, 4294242303, 5, 4294705149))
+            {
+                delete arenaTeam;
+                return false;
+            }
         }
 
         // Register arena team


### PR DESCRIPTION
Based on issue(s) https://github.com/azerothcore/mod-1v1-arena/issues/15 https://github.com/azerothcore/mod-1v1-arena/issues/13 https://github.com/azerothcore/mod-1v1-arena/issues/12

Added some fixes provided by https://github.com/peti446

The unrated arena was been removed from the 5v5 method.
Added a new config file with the option for change the method.
The patch don't change too much about the actual azerothcore structure and can be disabled without any problem.
The arena crystals work fine with both modes (using 5v5 arenas and 1v1 arenas).

Patch Pastebin Link: https://pastebin.com/Jw8XexQy

