### PR TITLE
feat: Changed to support 1v1 queue and added non hard coded forbiden talents

### DIFF
--- a/conf/1v1arena.conf.dist
+++ b/conf/1v1arena.conf.dist
@@ -10,40 +10,39 @@
 
 Arena1v1.Enable = 1
 
-#    NOT IMPLEMENTED
-#    Arena.1v1.Announcer
+#    Arena1v1.Announcer
 #        Description: Announce 1v1 arena queue status to chat.
 #                      Arena.QueueAnnouncer.Enable must be enabled.
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 
-Arena1v1Announcer.Enable = 1
+Arena1v1.Announcer = 1
 
 #
-#    Arena.1v1.MinLevel
+#    Arena1v1.MinLevel
 #        Description: Min level to create an arena team
 #        Default:     80
 
-Arena1v1MinLevel = 80
+Arena1v1.MinLevel = 80
 
 #
-#    Arena.1v1.Costs
+#    Arena1v1.Costs
 #        Description: Costs for create an arena team
 #        Default:     400000 - (40 gold)
 
-Arena1v1Costs = 400000
+Arena1v1.Costs = 400000
 
 #
-#    Arena.1v1.VendorRating
+#    Arena1v1.VendorRating
 #        Description: If true, 1v1 rating will use to calculate highest personal-rating (extended costs).
 #                      Note: The vendor-item will show as not buyable (red), but players can buy it, if enabled and rating is high enough.
 #        Default:     0 - (false)
-#                      1 - (true)
+#                     1 - (true)
 
-Arena.1v1.VendorRating = 0
+Arena1v1.VendorRating = 0
 
 #
-#    Arena.1v1.ArenaPointsMulti
+#    Arena1v1.ArenaPointsMulti
 #        Description: An 5v5 arena team with 1500 rating will gain 344 points per week (blizzlike).
 #                      3v3 with same rating will gain 302 points (5v5points * 0.88)
 #                      2v2 will gain 261 points (5v5points * 0.76)
@@ -51,16 +50,32 @@ Arena.1v1.VendorRating = 0
 #                      With this multiplier you can modify the arenapoints for 1v1.
 #        Default:     0.64
 
-Arena.1v1.ArenaPointsMulti = 0.64
+Arena1v1.ArenaPointsMulti = 0.64
 
 #
-#    Arena.1v1.BlockForbiddenTalents
+#    Arena1v1.BlockForbiddenTalents
 #        Description: If true, healers can't join 1v1 arena, if they invested more than 35 talentpoints in a healing-talenttree.
 #                      You can also block tanks and other talents, if you modify FORBIDDEN_TALENTS_IN_1V1_ARENA in the npc_arena1v1.h file (hardcoding). See TalentTab.dbc for available talents (you will need an DBC-Editor).
 #        Default:     1 - (true)
-#                      0 - (false)
+#                     0 - (false)
 
-Arena1v1BlockForbiddenTalents = 1
+Arena1v1.BlockForbiddenTalents = 1
+
+#
+#    Arena1v1.ForbiddenTalentsIDs
+#        Description: List to block specific talents id in arena. See TalentTab.dbc for available talents (you will need an DBC-Editor). The list is coma(,) separated and should have no spaces
+#        Default:     "0" - (no talent blocked)
+#		 Example:     "201,202,382,362,282,383,163"
+
+Arena1v1.ForbiddenTalentsIDs = "0"
+
+
+#
+#    Arena1v1.ArenaSlotID
+#        Description: The slot the 1v1 will be working over. Needs to be bigger or equals then 3 otherwise it will overwrite the 2v2,3v3 or 5v5 data
+#        Default:     3
+
+Arena1v1.ArenaSlotID = 3
 
 #
 ###################################################################################################

--- a/src/npc_arena1v1.cpp
+++ b/src/npc_arena1v1.cpp
@@ -83,7 +83,7 @@ public:
 
     void OnGetMaxPersonalArenaRatingRequirement(const Player* player, uint32 minslot, uint32& maxArenaRating) const override
     {
-        if (sConfigMgr->GetBoolDefault("Arena1v1.VendorRating", false) && minslot < sConfigMgr->GetIntDefault("Arena1v1.ArenaSlotID", 3))
+        if (sConfigMgr->GetBoolDefault("Arena1v1.VendorRating", false) && minslot < (uint32)sConfigMgr->GetIntDefault("Arena1v1.ArenaSlotID", 3))
         {
             if (ArenaTeam* at = sArenaTeamMgr->GetArenaTeamByCaptain(player->GetGUID(), ARENA_TEAM_1V1))
             {
@@ -265,7 +265,6 @@ private:
             return false;
         }
 
-        BattlegroundTypeId bgTypeId = bg->GetBgTypeID();
         PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bg->GetMapId(), player->getLevel());
         if (!bracketEntry)
             return false;

--- a/src/npc_arena1v1.cpp
+++ b/src/npc_arena1v1.cpp
@@ -20,32 +20,76 @@
 #include "ScriptedGossip.h"
 #include "Chat.h"
 
-// TalentTab.dbc -> TalentTabID
-/* const uint32 FORBIDDEN_TALENTS_IN_1V1_ARENA[] =
-{
-    // Healer
-    //201, // PriestDiscipline
-    //202, // PriestHoly
-    //382, // PaladinHoly
-    //262, // ShamanRestoration
-    //282, // DruidRestoration
+//Const for 1v1 arena
+constexpr uint32 ARENA_TEAM_1V1 = 1;
+constexpr uint32 ARENA_TYPE_1V1 = 1;
+constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int)BATTLEGROUND_QUEUE_5v5 + 1);
 
-    // Tanks
-    //383, // PaladinProtection
-    //163, // WarriorProtection
+//Config
+std::vector<uint32> forbiddenTalents;
 
-    0 // End
-};
-*/
-class arena1v1announce : public PlayerScript
+class configloader_1v1arena : public WorldScript
 {
 public:
-    arena1v1announce() : PlayerScript("arena1v1announce") { }
+    configloader_1v1arena() : WorldScript("configloader_1v1arena") {}
+
+
+    virtual void OnAfterConfigLoad(bool /*Reload*/) override
+    {
+        std::string blockedTalentsStr = sConfigMgr->GetStringDefault("Arena1v1.ForbiddenTalentsIDs", "");
+        Tokenizer toks(blockedTalentsStr, ',');
+        for (auto&& token : toks)
+        {
+            forbiddenTalents.push_back(std::stoi(token));
+        }
+    }
+
+};
+
+class playerscript_1v1arena : public PlayerScript
+{
+public:
+    playerscript_1v1arena() : PlayerScript("playerscript_1v1arena") { }
 
     void OnLogin(Player* pPlayer) override
     {
-        if (sConfigMgr->GetBoolDefault("Arena1v1Announcer.Enable", true))
+        if (sConfigMgr->GetBoolDefault("Arena1v1.Announcer", true))
             ChatHandler(pPlayer->GetSession()).SendSysMessage("This server is running the |cff4CFF00Arena 1v1 |rmodule.");
+    }
+
+    void GetCustomGetArenaTeamId(const Player* player, uint8 slot, uint32& id) const override
+    {
+        if (slot == sConfigMgr->GetIntDefault("Arena1v1.ArenaSlotID", 3))
+        {
+            if (ArenaTeam* at = sArenaTeamMgr->GetArenaTeamByCaptain(player->GetGUID(), ARENA_TEAM_1V1))
+            {
+                id = at->GetId();
+            }
+        }
+    }
+
+
+    void GetCustomArenaPersonalRating(const Player* player, uint8 slot, uint32& rating) const override
+    {
+        if (slot == sConfigMgr->GetIntDefault("Arena1v1.ArenaSlotID", 3))
+        {
+            if (ArenaTeam* at = sArenaTeamMgr->GetArenaTeamByCaptain(player->GetGUID(), ARENA_TEAM_1V1))
+            {
+                rating = at->GetRating();
+            }
+        }
+    }
+
+
+    void OnGetMaxPersonalArenaRatingRequirement(const Player* player, uint32 minslot, uint32& maxArenaRating) const override
+    {
+        if (sConfigMgr->GetBoolDefault("Arena1v1.VendorRating", false) && minslot < sConfigMgr->GetIntDefault("Arena1v1.ArenaSlotID", 3))
+        {
+            if (ArenaTeam* at = sArenaTeamMgr->GetArenaTeamByCaptain(player->GetGUID(), ARENA_TEAM_1V1))
+            {
+                maxArenaRating = std::max(at->GetRating(), maxArenaRating);
+            }
+        }
     }
 };
 
@@ -65,16 +109,22 @@ public:
             return true;
         }
 
-        if (player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
+        if (player->InBattlegroundQueueForBattlegroundQueueType(bgQueueTypeId))
+        {
             AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue leave 1v1 Arena", GOSSIP_SENDER_MAIN, 3, "Are you sure?", 0, false);
-        else
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena(UnRated)", GOSSIP_SENDER_MAIN, 20);
-
-        if (!player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5)))
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Create new 1v1 Arena Team", GOSSIP_SENDER_MAIN, 1, "Are you sure?", sConfigMgr->GetIntDefault("Arena1v1Costs", 400000), false);
+        }
         else
         {
-            if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
+            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena (UnRated)", GOSSIP_SENDER_MAIN, 20);
+        }
+
+        if (!player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_1V1)))
+        {
+            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Create new 1v1 Arena Team", GOSSIP_SENDER_MAIN, 1, "Are you sure?", sConfigMgr->GetIntDefault("Arena1v1.Costs", 400000), false);
+        }
+        else
+        {
+            if (!player->InBattlegroundQueueForBattlegroundQueueType(bgQueueTypeId))
             {
                 AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Queue enter 1v1 Arena (Rated)", GOSSIP_SENDER_MAIN, 2);
                 AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Arenateam Clear", GOSSIP_SENDER_MAIN, 5, "Are you sure?", 0, false);
@@ -100,14 +150,14 @@ public:
         {
         case 1: // Create new Arenateam
         {
-            if (sConfigMgr->GetIntDefault("Arena1v1MinLevel", 80) <= player->getLevel())
+            if (sConfigMgr->GetIntDefault("Arena1v1.MinLevel", 80) <= player->getLevel())
             {
-                if (player->GetMoney() >= uint32(sConfigMgr->GetIntDefault("Arena1v1Costs", 400000)) && CreateArenateam(player, creature))
-                    player->ModifyMoney(sConfigMgr->GetIntDefault("Arena1v1Costs", 400000) * -1);
+                if (player->GetMoney() >= uint32(sConfigMgr->GetIntDefault("Arena1v1.Costs", 400000)) && CreateArenateam(player, creature))
+                    player->ModifyMoney(sConfigMgr->GetIntDefault("Arena1v1.Costs", 400000) * -1);
             }
             else
             {
-                handler.PSendSysMessage("You have to be level %u + to create a 1v1 arena team.", sConfigMgr->GetIntDefault("Arena1v1MinLevel", 70));
+                handler.PSendSysMessage("You have to be level %u + to create a 1v1 arena team.", sConfigMgr->GetIntDefault("Arena1v1.MinLevel", 70));
                 CloseGossipMenuFor(player);
                 return true;
             }
@@ -136,9 +186,9 @@ public:
 
         case 3: // Leave Queue
         {
-            uint8 arenaType = ARENA_TYPE_5v5;
+            uint8 arenaType = ARENA_TYPE_1V1;
 
-            if (!player->InBattlegroundQueueForBattlegroundQueueType(BATTLEGROUND_QUEUE_5v5))
+            if (!player->InBattlegroundQueueForBattlegroundQueueType(bgQueueTypeId))
                 return true;
 
             WorldPacket data;
@@ -151,7 +201,7 @@ public:
 
         case 4: // get statistics
         {
-            ArenaTeam* at = sArenaTeamMgr->GetArenaTeamById(player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5)));
+            ArenaTeam* at = sArenaTeamMgr->GetArenaTeamById(player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_1V1)));
             if (at)
             {
                 std::stringstream s;
@@ -170,7 +220,7 @@ public:
         case 5: // Disband arenateam
         {
             WorldPacket Data;
-            Data << (uint32)player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_5v5));
+            Data << player->GetArenaTeamId(ArenaTeam::GetSlotByType(ARENA_TEAM_1V1));
             player->GetSession()->HandleArenaTeamLeaveOpcode(Data);
             handler.SendSysMessage("Arenateam deleted!");
             CloseGossipMenuFor(player);
@@ -189,11 +239,11 @@ private:
         if (!player || !me)
             return false;
 
-        if (sConfigMgr->GetIntDefault("Arena1v1MinLevel", 80) > player->getLevel())
+        if (sConfigMgr->GetIntDefault("Arena1v1.MinLevel", 80) > player->getLevel())
             return false;
 
-        uint8 arenaslot = ArenaTeam::GetSlotByType(ARENA_TEAM_5v5);
-        uint8 arenatype = ARENA_TYPE_5v5;
+        uint8 arenaslot = ArenaTeam::GetSlotByType(ARENA_TEAM_1V1);
+        uint8 arenatype = ARENA_TYPE_1V1;
         uint32 arenaRating = 0;
         uint32 matchmakerRating = 0;
 
@@ -216,7 +266,6 @@ private:
         }
 
         BattlegroundTypeId bgTypeId = bg->GetBgTypeID();
-        BattlegroundQueueTypeId bgQueueTypeId = BattlegroundMgr::BGQueueTypeId(bgTypeId, arenatype);
         PvPDifficultyEntry const* bracketEntry = GetBattlegroundBracketByLevel(bg->GetMapId(), player->getLevel());
         if (!bracketEntry)
             return false;
@@ -251,7 +300,9 @@ private:
         }
 
         BattlegroundQueue& bgQueue = sBattlegroundMgr->GetBattlegroundQueue(bgQueueTypeId);
+        bgQueue.SetBgTypeIdAndArenaType(BATTLEGROUND_AA, ARENA_TYPE_1V1);
         bg->SetRated(isRated);
+        bg->SetMaxPlayersPerTeam(1);
 
         GroupQueueInfo* ginfo = bgQueue.AddGroup(player, nullptr, bracketEntry, isRated, false, arenaRating, matchmakerRating, ateamId);
         uint32 avgTime = bgQueue.GetAverageQueueWaitTime(ginfo);
@@ -272,8 +323,9 @@ private:
         if (!player || !me)
             return false;
 
-        uint8 slot = ArenaTeam::GetSlotByType(ARENA_TEAM_5v5);
-        if (slot >= MAX_ARENA_SLOT)
+        uint8 slot = ArenaTeam::GetSlotByType(ARENA_TEAM_1V1);
+        //Just to make sure as some other module might edit this value
+        if (slot == 0)
             return false;
 
         // Check if player is already in an arena team
@@ -288,7 +340,6 @@ private:
         int i = 1;
         std::stringstream teamName;
         teamName << player->GetName();
-
         do
         {
             if (sArenaTeamMgr->GetArenaTeamByName(teamName.str()) != NULL) // teamname exist, so choose another name
@@ -302,7 +353,7 @@ private:
 
         // Create arena team
         ArenaTeam* arenaTeam = new ArenaTeam();
-        if (!arenaTeam->Create(player->GetGUID(), ARENA_TEAM_5v5, teamName.str(), 4283124816, 45, 4294242303, 5, 4294705149))
+        if (!arenaTeam->Create(player->GetGUID(), ARENA_TEAM_1V1, teamName.str(), 4283124816, 45, 4294242303, 5, 4294705149))
         {
             delete arenaTeam;
             return false;
@@ -321,7 +372,7 @@ private:
         if (!player)
             return false;
 
-        if (sConfigMgr->GetBoolDefault("Arena1v1BlockForbiddenTalents", true) == false)
+        if (sConfigMgr->GetBoolDefault("Arena1v1.BlockForbiddenTalents", true) == false)
             return true;
 
         uint32 count = 0;
@@ -332,6 +383,12 @@ private:
 
             if (!talentInfo)
                 continue;
+
+            if (std::find(forbiddenTalents.begin(), forbiddenTalents.end(), talentInfo->TalentID) != forbiddenTalents.end())
+            {
+                ChatHandler(player->GetSession()).SendSysMessage("You can not join because you have forbidden talents.");
+                return false;
+            }
 
             for (int8 rank = MAX_TALENT_RANK - 1; rank >= 0; --rank)
                 if (talentInfo->RankID[rank] == 0)
@@ -348,8 +405,62 @@ private:
     }
 };
 
+class team_1v1arena : public ArenaTeamScript
+{
+public:
+    team_1v1arena() : ArenaTeamScript("team_1v1arena") {}
+
+
+    void OnGetSlotByType(const uint32 type, uint8& slot) override
+    {
+        if (type == ARENA_TEAM_1V1)
+        {
+            slot = sConfigMgr->GetIntDefault("Arena1v1.ArenaSlotID", 3);
+        }
+    }
+
+
+    void OnGetArenaPoints(ArenaTeam* at, float& points) override
+    {
+        if (at->GetType() == ARENA_TEAM_1V1)
+        {
+            points *= sConfigMgr->GetFloatDefault("Arena1v1.ArenaPointsMulti", 0.64f);
+        }
+    }
+
+
+    void OnTypeIDToQueueID(const BattlegroundTypeId, const uint8 arenaType, uint32& _bgQueueTypeId) override
+    {
+        if (arenaType == ARENA_TYPE_1V1)
+        {
+            _bgQueueTypeId = bgQueueTypeId;
+        }
+    }
+
+
+    void OnQueueIdToArenaType(const BattlegroundQueueTypeId _bgQueueTypeId, uint8& arenaType) override
+    {
+        if (_bgQueueTypeId == bgQueueTypeId)
+        {
+            arenaType = ARENA_TYPE_1V1;
+        }
+    }
+
+
+    void OnSetArenaMaxPlayersPerTeam(const uint8 type, uint32& maxPlayersPerTeam) override
+    {
+        if (type == ARENA_TYPE_1V1)
+        {
+            maxPlayersPerTeam = 1;
+        }
+    }
+
+};
+
 void AddSC_npc_1v1arena()
 {
-    new arena1v1announce();
+    new configloader_1v1arena();
+    new playerscript_1v1arena();
     new npc_1v1arena();
+    new team_1v1arena();
 }


### PR DESCRIPTION
Requires this PR to be merged: https://github.com/azerothcore/azerothcore-wotlk/pull/3508 before this can be merged without errors.

Fixes: https://github.com/azerothcore/mod-1v1-arena/issues/15 https://github.com/azerothcore/mod-1v1-arena/issues/13 https://github.com/azerothcore/mod-1v1-arena/issues/12

Features and changes:
The arena will now work over its own queue instead of 5v5
Added a new config file with the option to set the blocked talents list
The arena crystals work correctly