### PR TITLE
fix(patch): Fix bugs with 1v1 queue system, Battlemaster NPC Crashing and Ready Mark Crystals 

### DIFF
--- a/src/npc_arena1v1.cpp
+++ b/src/npc_arena1v1.cpp
@@ -12,18 +12,22 @@
 #include "DisableMgr.h"
 #include "BattlegroundMgr.h"
 #include "Battleground.h"
+#include "BattlegroundQueue.h"
 #include "ArenaTeam.h"
 #include "Language.h"
 #include "Config.h"
 #include "Log.h"
 #include "Player.h"
 #include "ScriptedGossip.h"
+#include "SharedDefines.h"
 #include "Chat.h"
 
 //Const for 1v1 arena
 constexpr uint32 ARENA_TEAM_1V1 = 1;
 constexpr uint32 ARENA_TYPE_1V1 = 1;
+constexpr uint32 BATTLEGROUND_QUEUE_1V1 = 11;
 constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int)BATTLEGROUND_QUEUE_5v5 + 1);
+uint32 ARENA_SLOT_1V1 = 3;
 
 //Config
 std::vector<uint32> forbiddenTalents;
@@ -42,6 +46,14 @@ public:
         {
             forbiddenTalents.push_back(std::stoi(token));
         }
+        ARENA_SLOT_1V1 = sConfigMgr->GetIntDefault("Arena1v1.ArenaSlotID", 3);
+        
+        ArenaTeam::ArenaSlotByType.insert({ ARENA_TEAM_1V1, ARENA_SLOT_1V1 });
+        ArenaTeam::ArenaReqPlayersForType.insert({ ARENA_TYPE_1V1, 2 });
+        
+        BattlegroundMgr::queueToBg.insert({ BATTLEGROUND_QUEUE_1V1,   BATTLEGROUND_AA });
+        BattlegroundMgr::QueueToArenaType.emplace(BATTLEGROUND_QUEUE_1V1, (ArenaType) ARENA_TYPE_1V1);
+        BattlegroundMgr::ArenaTypeToQueue.emplace(ARENA_TYPE_1V1, (BattlegroundQueueTypeId) BATTLEGROUND_QUEUE_1V1);
     }
 
 };
@@ -56,6 +68,7 @@ public:
         if (sConfigMgr->GetBoolDefault("Arena1v1.Announcer", true))
             ChatHandler(pPlayer->GetSession()).SendSysMessage("This server is running the |cff4CFF00Arena 1v1 |rmodule.");
     }
+
 
     void GetCustomGetArenaTeamId(const Player* player, uint8 slot, uint32& id) const override
     {


### PR DESCRIPTION
## Changes Proposed:
- Add structure to arena 1v1 queue and type
- This fix the current script proposed on the module system, didn't affecting the blizzlike arena system (2v2, 3v3, 5v5 and skirmish modes).

## Related PRs/Issues:
- https://github.com/azerothcore/azerothcore-wotlk/pull/6401
- https://github.com/azerothcore/mod-1v1-arena/issues/27#issuecomment-862779969

## Tests performed:
- Builded without errors with docker and manually
- Tested in-game with the arena 1v1 module
- Tested in-game the blizzlike arena models (2v2, 3v3 and 5v5)

## How to test the changes:
- Make an fresh install of azerothcore and add arena1v1 module
- Test in-game.

## Images:

![](https://i.imgur.com/6rMaXIy.png)
![](https://i.imgur.com/RYWeIDn.png)
![](https://i.imgur.com/4f5qmdd.png)
![](https://i.imgur.com/MWWEIFO.png)
![](https://i.imgur.com/yssdwyc.png)
![](https://i.imgur.com/0647zFj.png)
![](https://i.imgur.com/bcKrvOQ.png)
![](https://i.imgur.com/bgZWwuK.png)
![](https://i.imgur.com/6XpwQYJ.png)