### PR TITLE
chore. Prevent tanks and heals in config

### DIFF
--- a/conf/1v1arena.conf.dist
+++ b/conf/1v1arena.conf.dist
@@ -53,13 +53,22 @@ Arena1v1.VendorRating = 0
 Arena1v1.ArenaPointsMulti = 0.64
 
 #
-#    Arena1v1.BlockForbiddenTalents
-#        Description: If true, healers can't join 1v1 arena, if they invested more than 35 talentpoints in a healing-talenttree.
-#                      You can also block tanks and other talents, if you modify FORBIDDEN_TALENTS_IN_1V1_ARENA in the npc_arena1v1.h file (hardcoding). See TalentTab.dbc for available talents (you will need an DBC-Editor).
-#        Default:     1 - (true)
-#                     0 - (false)
+#   Arena1v1.PreventHealingTalents
+#       Description: If enabled, it prevents people from having healing talents.
+#       Default: false
+#       Value:   false
+#                true
 
-Arena1v1.BlockForbiddenTalents = 1
+Arena1v1.PreventHealingTalents = false
+
+#
+#   Arena1v1.PreventTankTalents
+#       Description: If enabled, it prevents people from having tank talents.
+#       Default: false
+#       Value:   false
+#                true
+
+Arena1v1.PreventTankTalents = false
 
 #
 #    Arena1v1.ForbiddenTalentsIDs
@@ -68,7 +77,6 @@ Arena1v1.BlockForbiddenTalents = 1
 #           Example:     "201,202,382,362,282,383,163"
 
 Arena1v1.ForbiddenTalentsIDs = "0"
-
 
 #
 #    Arena1v1.ArenaSlotID

--- a/src/npc_arena1v1.cpp
+++ b/src/npc_arena1v1.cpp
@@ -401,32 +401,15 @@ private:
         if (!player)
             return false;
 
-        if (sConfigMgr->GetOption<bool>("Arena1v1.BlockForbiddenTalents", true) == false)
-            return true;
-
-        uint32 count = 0;
-
-        for (uint32 talentId = 0; talentId < sTalentStore.GetNumRows(); ++talentId)
+        if (player->HasHealSpec() && (sConfigMgr->GetOption<bool>("Arena1v1.PreventHealingTalents", false)))
         {
-            TalentEntry const* talentInfo = sTalentStore.LookupEntry(talentId);
-
-            if (!talentInfo)
-                continue;
-
-            if (std::find(forbiddenTalents.begin(), forbiddenTalents.end(), talentInfo->TalentID) != forbiddenTalents.end())
-            {
-                ChatHandler(player->GetSession()).SendSysMessage("You can not join because you have forbidden talents.");
-                return false;
-            }
-
-            for (int8 rank = MAX_TALENT_RANK - 1; rank >= 0; --rank)
-                if (talentInfo->RankID[rank] == 0)
-                    continue;
+            ChatHandler(player->GetSession()).SendSysMessage("You can't join because you have forbidden talents (Heal)");
+            return false;
         }
 
-        if (count >= 36)
+        if (player->HasTankSpec() && (sConfigMgr->GetOption<bool>("Arena1v1.PreventTankTalents", false)))
         {
-            ChatHandler(player->GetSession()).SendSysMessage("You can not join because you have too many talent points in a forbidden tree. (Heal / Tank)");
+            ChatHandler(player->GetSession()).SendSysMessage("You can't join because you have forbidden talents (Tank)");
             return false;
         }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- The idea of the pull request is to prevent tanks and heals from scoring arenas, however, it is a configurable option, and by default it is disabled. Within the configuration file, each server will be able to choose whether it wants to enable one or both, or neither.
-  The functionality of counting the number of talents and limiting it by the number of talents remains to be implemented, but that is a matter for another pull request.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-1v1-arena/issues/29
- Closes https://github.com/azerothcore/mod-1v1-arena/pull/49

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Score sands as normal and test.
2. Add a heal talent and enable the configuration file option, you will see that it will not let you score.
3. Repeat the process for the tank branch, it should not stop either, if the option is set to true.
4. Both options are disabled by default.