### PR TITLE
fix(DB/World): add missing 'q1v1 stats' to DELETE statement

### DIFF
--- a/data/sql/db-world/base/1v1_Battlemaster.sql
+++ b/data/sql/db-world/base/1v1_Battlemaster.sql
@@ -9,7 +9,7 @@ DELETE FROM `battlemaster_entry` WHERE `entry`=999991;
 INSERT INTO `battlemaster_entry` (`entry`, `bg_template`) VALUES (999991, 6);
 
 -- Command
-DELETE FROM `command` WHERE `name` IN ('q1v1', 'q1v1 rated', 'q1v1 unrated');
+DELETE FROM `command` WHERE `name` IN ('q1v1', 'q1v1 rated', 'q1v1 unrated', 'q1v1 stats');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('q1v1', 0, 'Syntax .q1v1 rated/unrate\nJoin arena 1v1 rated or unrated'),
 ('q1v1 rated', 0, 'Syntax .q1v1 rated\nJoin arena 1v1 rated'),


### PR DESCRIPTION
## Summary
- The `DELETE FROM command` statement on line 12 of `1v1_Battlemaster.sql` was missing the `'q1v1 stats'` entry, while the subsequent `INSERT` on line 17 includes it.
- This causes `ERROR 1062 (23000): Duplicate entry 'q1v1 stats' for key 'command.PRIMARY'` when the SQL file is applied and the entry already exists.
- Added `'q1v1 stats'` to the `DELETE ... WHERE name IN (...)` clause so the insert always succeeds.

## Test plan
- [ ] Apply the SQL file to a fresh `acore_world` database — should succeed
- [ ] Apply the SQL file a second time — should still succeed (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)